### PR TITLE
Fix backface culling causing missing faces on Trackwork spinning wheels

### DIFF
--- a/src/main/java/com/moepus/createbetterfps/renderer/SodiumByteBuffer.java
+++ b/src/main/java/com/moepus/createbetterfps/renderer/SodiumByteBuffer.java
@@ -430,7 +430,7 @@ public class SodiumByteBuffer implements SuperByteBuffer {
             pos1.set(template.x(i + 1), template.y(i + 1), template.z(i + 1)).mulPosition(modelMat);
             pos2.set(template.x(i + 2), template.y(i + 2), template.z(i + 2)).mulPosition(modelMat);
 
-            if (isPerspectiveProjection) {
+            if (isPerspectiveProjection) { // do backface culling
                 float ex = pos1.x - pos0.x, ey = pos1.y - pos0.y, ez = pos1.z - pos0.z;
                 float fx = pos2.x - pos0.x, fy = pos2.y - pos0.y, fz = pos2.z - pos0.z;
                 float cx = ey * fz - ez * fy;
@@ -581,7 +581,7 @@ public class SodiumByteBuffer implements SuperByteBuffer {
             pos1.set(template.x(i + 1), template.y(i + 1), template.z(i + 1)).mulPosition(modelMat);
             pos2.set(template.x(i + 2), template.y(i + 2), template.z(i + 2)).mulPosition(modelMat);
 
-            if (isPerspectiveProjection) {
+            if (isPerspectiveProjection) { // do backface culling
                 float ex = pos1.x - pos0.x, ey = pos1.y - pos0.y, ez = pos1.z - pos0.z;
                 float fx = pos2.x - pos0.x, fy = pos2.y - pos0.y, fz = pos2.z - pos0.z;
                 float cx = ey * fz - ez * fy;

--- a/src/main/java/com/moepus/createbetterfps/renderer/SodiumByteBuffer.java
+++ b/src/main/java/com/moepus/createbetterfps/renderer/SodiumByteBuffer.java
@@ -427,11 +427,18 @@ public class SodiumByteBuffer implements SuperByteBuffer {
             float nz = MatrixHelper.transformNormalZ(normalMat, unpackedX, unpackedY, unpackedZ);
 
             pos0.set(template.x(i), template.y(i), template.z(i)).mulPosition(modelMat);
-            pos2.set(template.x(i + 2), template.y(i + 2), template.z(i + 2)).mulPosition(modelMat);
-            if (isPerspectiveProjection) { // do backface culling
-                if (nx * (pos0.x + pos2.x) + ny * (pos0.y + pos2.y) + nz * (pos0.z + pos2.z) > 0) continue;
-            }
             pos1.set(template.x(i + 1), template.y(i + 1), template.z(i + 1)).mulPosition(modelMat);
+            pos2.set(template.x(i + 2), template.y(i + 2), template.z(i + 2)).mulPosition(modelMat);
+
+            if (isPerspectiveProjection) {
+                float ex = pos1.x - pos0.x, ey = pos1.y - pos0.y, ez = pos1.z - pos0.z;
+                float fx = pos2.x - pos0.x, fy = pos2.y - pos0.y, fz = pos2.z - pos0.z;
+                float cx = ey * fz - ez * fy;
+                float cy = ez * fx - ex * fz;
+                float cz = ex * fy - ey * fx;
+                if (cx * (pos0.x + pos2.x) + cy * (pos0.y + pos2.y) + cz * (pos0.z + pos2.z) > 0) continue;
+            }
+
             pos3.set(template.x(i + 3), template.y(i + 3), template.z(i + 3)).mulPosition(modelMat);
 
             int normal = NormI8.pack(nx, ny, nz);
@@ -571,12 +578,19 @@ public class SodiumByteBuffer implements SuperByteBuffer {
             float nz = MatrixHelper.transformNormalZ(normalMat, unpackedX, unpackedY, unpackedZ);
 
             pos0.set(template.x(i), template.y(i), template.z(i)).mulPosition(modelMat);
-            pos2.set(template.x(i + 2), template.y(i + 2), template.z(i + 2)).mulPosition(modelMat);
-            if (isPerspectiveProjection) { // do backface culling
-                if (nx * (pos0.x + pos2.x) + ny * (pos0.y + pos2.y) + nz * (pos0.z + pos2.z) > 0) continue;
-            }
-            int normal = NormI8.pack(nx, ny, nz);
             pos1.set(template.x(i + 1), template.y(i + 1), template.z(i + 1)).mulPosition(modelMat);
+            pos2.set(template.x(i + 2), template.y(i + 2), template.z(i + 2)).mulPosition(modelMat);
+
+            if (isPerspectiveProjection) {
+                float ex = pos1.x - pos0.x, ey = pos1.y - pos0.y, ez = pos1.z - pos0.z;
+                float fx = pos2.x - pos0.x, fy = pos2.y - pos0.y, fz = pos2.z - pos0.z;
+                float cx = ey * fz - ez * fy;
+                float cy = ez * fx - ex * fz;
+                float cz = ex * fy - ey * fx;
+                if (cx * (pos0.x + pos2.x) + cy * (pos0.y + pos2.y) + cz * (pos0.z + pos2.z) > 0) continue;
+            }
+
+            int normal = NormI8.pack(nx, ny, nz);
             pos3.set(template.x(i + 3), template.y(i + 3), template.z(i + 3)).mulPosition(modelMat);
 
             if (spriteShiftFunc != null) {


### PR DESCRIPTION
## Problem:
`SodiumRenderInto()` and `IrisRenderInto()` used the template normal (`nx`, `ny`, `nz`) for CPU-side backface culling. These normals pass through `NormI8.pack()` then `NormI8.unpack()` (i8 quantization), then through the normal matrix (multiple rotation transforms). The quantization error accumulates through compound transforms (center, rotateY, translate, rotateX, uncenter), causing the normal to drift from the true geometric normal at grazing angles. At specific wheel rotation angles and camera positions, this drift flips the culling sign, causing front-facing quads to be incorrectly discarded. As seen in #7  

## Symptom: 
Faces randomly disappear on Trackwork's powered wheels at specific camera angles and rotation positions.

## Root cause: 
i8 normal quantization (~7 bits per component precision) is insufficient for the dot-product culling test n . (p0 + p2) > 0 after multiple matrix transforms. The geometric cross-product (p1-p0) x (p2-p0) retains full float precision.

## Fix: 
Replace template-normal-based culling with geometric cross-product from actual transformed vertex positions in both `SodiumRenderInto()` and `IrisRenderInto()`. `IrisRenderShadowInto()` (sun-direction culling) was not affected and is unchanged.

## Files changed:
 `SodiumByteBuffer.java` - only `SodiumRenderInto()` and `IrisRenderInto()`, ~10 lines changed total.

## Verification:
 No visual artifacts at any angle or rotation speed and marginal performance impact + verified 50% quad culling ratio. 
 
<img width="854" height="480" alt="2026-04-13_13 05 05" src="https://github.com/user-attachments/assets/16b0fb28-6d17-4ac5-91d9-1b8b3f4e4038" />

 
<img width="854" height="480" alt="2026-04-13_13 35 52" src="https://github.com/user-attachments/assets/e57c8f06-ceb1-4431-958a-f2510c137a58" />

(these two are after the fix)

VV culling *with* wheels VV
```
[13:29:57] [Render thread/INFO]: [CBFPS] quads: 925344 culled: 456543 (49,3%)
[13:29:58] [Render thread/INFO]: [CBFPS] quads: 1048086 culled: 517118 (49,3%)
[13:29:59] [Render thread/INFO]: [CBFPS] quads: 1128762 culled: 556905 (49,3%)
[13:30:00] [Render thread/INFO]: [CBFPS] quads: 901584 culled: 444833 (49,3%)
[13:30:01] [Render thread/INFO]: [CBFPS] quads: 1100736 culled: 543116 (49,3%)
[13:30:02] [Render thread/INFO]: [CBFPS] quads: 919296 culled: 450022 (49,0%)
[13:30:03] [Render thread/INFO]: [CBFPS] quads: 1003968 culled: 490843 (48,9%)
[13:30:04] [Render thread/INFO]: [CBFPS] quads: 1058400 culled: 516055 (48,8%)
```

VV and *without* wheels VV
```
[13:30:51] [Render thread/INFO]: [CBFPS] quads: 39312 culled: 21802 (55,5%)
[13:30:52] [Render thread/INFO]: [CBFPS] quads: 45360 culled: 23192 (51,1%)
[13:30:53] [Render thread/INFO]: [CBFPS] quads: 44928 culled: 23829 (53,0%)
[13:30:54] [Render thread/INFO]: [CBFPS] quads: 45144 culled: 24550 (54,4%)
[13:30:55] [Render thread/INFO]: [CBFPS] quads: 49248 culled: 26415 (53,6%)
[13:30:56] [Render thread/INFO]: [CBFPS] quads: 50112 culled: 28551 (57,0%)
[13:30:57] [Render thread/INFO]: [CBFPS] quads: 51408 culled: 27201 (52,9%)
[13:30:58] [Render thread/INFO]: [CBFPS] quads: 48816 culled: 27212 (55,7%)
[13:30:59] [Render thread/INFO]: [CBFPS] quads: 44064 culled: 24175 (54,9%)
```